### PR TITLE
Arena State manager implementation

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -8,9 +8,20 @@
 
 config_version=4
 
-_global_script_classes=[  ]
+_global_script_classes=[ {
+"base": "Resource",
+"class": "ArenaState",
+"language": "GDScript",
+"path": "res://resources/scripts/ArenaState.gd"
+}, {
+"base": "TileMap",
+"class": "TilemapHandler",
+"language": "GDScript",
+"path": "res://resources/scripts/TilemapHandler.gd"
+} ]
 _global_script_class_icons={
-
+"ArenaState": "",
+"TilemapHandler": ""
 }
 
 [application]

--- a/resources/scripts/ArenaState.gd
+++ b/resources/scripts/ArenaState.gd
@@ -1,0 +1,26 @@
+extends Resource
+
+class_name ArenaState
+
+var matrix : Array = []
+var offset : Vector2 = Vector2(0, 0)
+
+func _init(tilemap: TileMap):
+	var rects: Rect2 = tilemap.rects
+	# Assign offset based on first tile position
+	offset = rects.position
+
+	# Assign the default matrix based on tilemap size
+	for row in rects.size.x:
+		matrix.append([])
+		for col in rects.size.y:
+			matrix[row].append(0)
+			
+func map_to_matrix(map_position: Vector2):
+	return map_position - offset
+
+func _pretty_print():
+	print("Arena matrix")
+	for row in matrix:
+		print(row)
+	print("============")

--- a/resources/scripts/LevelHandler.gd
+++ b/resources/scripts/LevelHandler.gd
@@ -3,10 +3,12 @@ extends Node2D
 # Prefetch external modules
 const UIDrawer: Script = preload("res://resources/scripts/UIDrawer.gd")
 const InputHandler: Script = preload("res://resources/scripts/InputHandler.gd")
+const ArenaState: Script = preload("res://resources/scripts/ArenaState.gd")
 
 # Initialize extenral modules
 onready var uiDrawer = UIDrawer.new(self)
 onready var inputHandler = InputHandler.new()
+onready var arenaState: ArenaState = ArenaState.new($TileMap)
 
 func _ready():
 	# Input handler must be assigned on the scene to share signals
@@ -16,23 +18,33 @@ func _ready():
 	inputHandler.connect("mouse_click", self, "_on_mouse_click")
 	inputHandler.connect("mouse_hover", self, "_on_mouse_hover")
 
-	# Invoke any post-initialization inputHandler action
+	# Invoke post-initialization inputHandler action
 	inputHandler.post_init()
-
-func try_draw(tile_position, tile_type):
-	if tile_position == null:
-		uiDrawer.try_reset_current()
-	else:
-		uiDrawer.draw_tile(tile_position, tile_type)
 	
-	return tile_position == null
+	# Debug arena matrix
+	arenaState._pretty_print()
+
+func try_handle_interaction(interaction_position, effect_type):
+	var tile_position = $TileMap.get_tile_position_at(interaction_position)
+	
+	# If action happend on invalid tile
+	if tile_position == null:
+		# Remove any existing objects
+		uiDrawer.try_reset_current()
+		return false
+		
+	if effect_type == uiDrawer.EFFECT_TYPES.CLICK:
+		print(tile_position, arenaState.map_to_matrix(tile_position.map_position))
+
+	# Otherwise, draw the object based on the received tile world position
+	uiDrawer.draw_tile_effect(tile_position.world_position, effect_type)
+
+	return true
 
 # Mouse click event handler
 func _on_mouse_click(click_position):	
-	var tile_position = $TileMap.get_tile_position_at(click_position)
-	try_draw(tile_position, uiDrawer.TILE_TYPES_ENUM.CLICK)
+	try_handle_interaction(click_position, uiDrawer.EFFECT_TYPES.CLICK)
 
 # Mouse hover event handler
 func _on_mouse_hover(hover_position):
-	var tile_position = $TileMap.get_tile_position_at(hover_position)
-	try_draw(tile_position, uiDrawer.TILE_TYPES_ENUM.HOVER)
+	try_handle_interaction(hover_position, uiDrawer.EFFECT_TYPES.HOVER)

--- a/resources/scripts/TilemapHandler.gd
+++ b/resources/scripts/TilemapHandler.gd
@@ -1,20 +1,28 @@
 extends TileMap
 
+class_name TilemapHandler
+
+# Internal fields
 var cells : Array = []
+var rects : Rect2 = Rect2()
 
 func _init():
+	# Initialize internal fields
 	cells = get_used_cells()
+	rects = get_used_rect()
 
 func _exists(tile_position: Vector2):
 	return cells.find(tile_position) != -1
 
 # Helper function to transform coordinates using tilemap API
 func get_tile_position_at(world_position: Vector2):
-	var requested_position: Vector2 = world_to_map(world_position)
-	
+	var tile_map_position: Vector2 = world_to_map(world_position)
+
 	# Return if tile doesn't exist on the tilemap
-	if not _exists(requested_position):
+	if not _exists(tile_map_position):
 		return null
-	
+		
+	var tile_world_position = map_to_world(tile_map_position)
+
 	# Otherwise, calculate and return tile position in the world
-	return map_to_world(requested_position)
+	return { "map_position": tile_map_position, "world_position": tile_world_position }

--- a/resources/scripts/UIDrawer.gd
+++ b/resources/scripts/UIDrawer.gd
@@ -1,29 +1,29 @@
 extends Node
 
-enum TILE_TYPES_ENUM {HOVER,CLICK}
+enum EFFECT_TYPES {HOVER,CLICK}
 
 var level: Node2D;
 var current_tile = get_current_defaults();
 
 # To switch to a different theme, update /tiles/<THEME>/ part here
-const TILES = {
-	TILE_TYPES_ENUM.HOVER: preload("res://resources/tile_effects/bright_moon/hover_effect.tscn"), 
-	TILE_TYPES_ENUM.CLICK: preload("res://resources/tile_effects/bright_moon/click_effect.tscn")
+const EFFECTS = {
+	EFFECT_TYPES.HOVER: preload("res://resources/tile_effects/bright_moon/hover_effect.tscn"), 
+	EFFECT_TYPES.CLICK: preload("res://resources/tile_effects/bright_moon/click_effect.tscn")
 }
 
 func _init(level_object: Node2D):
 	level = level_object
 
-func draw_tile(tile_position: Vector2, tile_type = TILE_TYPES_ENUM.HOVER):
+func draw_tile_effect(tile_position: Vector2, effect_type = EFFECTS.HOVER):
 	# If tile position is the same -> skip further execution
-	if tile_position == current_tile.position and tile_type == current_tile.type:
+	if tile_position == current_tile.position and effect_type == current_tile.type:
 		return
 		
 	# Make sure to reset any existing tiles
 	try_reset_current()
 
 	# Instantiate a new tile object
-	var tile_object : AnimatedSprite = TILES[tile_type].instance()
+	var tile_object : AnimatedSprite = EFFECTS[effect_type].instance()
 
 	# Assign new tile object properties
 	tile_object.position = Vector2(tile_position.x, tile_position.y)
@@ -35,7 +35,7 @@ func draw_tile(tile_position: Vector2, tile_type = TILE_TYPES_ENUM.HOVER):
 	level.add_child(tile_object)
 
 	# Save reference to a current tile
-	current_tile.type = tile_type
+	current_tile.type = effect_type
 	current_tile.object = tile_object
 	current_tile.position = tile_position
 	


### PR DESCRIPTION
**General:**
- [x] Add `ArenaState.gc`
- [ ] Define the matrix values map for: empty tiles, heroes/champions, obstacles.

**ArenaState:**
- [ ] Create arena state from a predefined matrix.
- [ ] Return a state of the tile by its position.

**LevelHandler:**
- [ ] Use `ArenaState` and `UIDrawer` to draw initial state of the arena.
- [ ] Use `ArenaState` to check interacted tile state.
- [ ] Use `UIDrawer` to draw tile state.

**UIDrawer:**
- [ ] Add support for drawing non-effect objects like heroes/champions and obstacles tiles.

**Assets:**
- [ ] Add 1 static obstacle sprite
- [ ] Add 1 hero/champion animated sprite